### PR TITLE
added actionbar titles for each page

### DIFF
--- a/Bumerang/app/src/main/AndroidManifest.xml
+++ b/Bumerang/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
-
+            
         </activity>
 
         <activity

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/Browse.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/Browse.java
@@ -30,6 +30,8 @@ public class Browse extends ListFragment implements OnItemClickListener {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_browse_list, container, false);
 
+        ((Home)getActivity()).setActionBarTitle("Lend");
+
         return view;
     }
 
@@ -56,6 +58,7 @@ public class Browse extends ListFragment implements OnItemClickListener {
         super.onActivityCreated(savedInstanceState);
         setListAdapter(adapter);
         getListView().setOnItemClickListener(this);
+
 
     }
 

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/CreateRequest.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/CreateRequest.java
@@ -30,6 +30,9 @@ public class CreateRequest extends Fragment {
     // Fragment Cancel = new Browse();
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+
+        ((Home)getActivity()).setActionBarTitle("Create Request");
+
         inflatedView = inflater.inflate(R.layout.activity_create_request, container, false);
 
         // Setup for Seekbars

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/EditProfileFragment.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/EditProfileFragment.java
@@ -32,6 +32,9 @@ public class EditProfileFragment extends Fragment {
                              Bundle savedInstanceState) {
         inflatedView = inflater.inflate(R.layout.fragment_edit_profile, container, false);
 
+        //this is crashing the app because there's no actionbar the first time you see the edit profile page
+        //((Home)getActivity()).setActionBarTitle("Edit Profile");
+
         // Check if the user already has a profile
         if (Connectivity.checkNetworkConnection(getApplicationContext())) {
             new LoadProfileTask().execute(profileUrl);
@@ -79,6 +82,7 @@ public class EditProfileFragment extends Fragment {
 
         return inflatedView;
     }
+
 
     private void populateFields() {
 

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/Home.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/Home.java
@@ -27,6 +27,7 @@ public class Home extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_nav_drawer);
+        //toolbar/actionbar setup
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
@@ -95,6 +96,13 @@ public class Home extends AppCompatActivity
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    public void setActionBarTitle(String title){
+        if (getSupportActionBar().isShowing()){
+            getSupportActionBar().setTitle(title);
+        }
+
     }
 
     @SuppressWarnings("StatementWithEmptyBody")

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/MyRequests.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/MyRequests.java
@@ -32,6 +32,8 @@ public class MyRequests extends ListFragment implements OnItemClickListener {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_myrequests_list, container, false);
 
+        ((Home)getActivity()).setActionBarTitle("My Requests");
+
         return view;
     }
 
@@ -53,6 +55,7 @@ public class MyRequests extends ListFragment implements OnItemClickListener {
         setListAdapter(adapter);
 
         getListView().setOnItemClickListener(this);
+
 
     }
 

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/ProfilePage.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/ProfilePage.java
@@ -31,6 +31,8 @@ public class ProfilePage extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         myInflatedView = inflater.inflate(R.layout.fragment_profile_page, container,false);
 
+        ((Home)getActivity()).setActionBarTitle("Profile");
+
         GraphRequest request = GraphRequest.newMeRequest(AccessToken.getCurrentAccessToken(),
 
                 new GraphRequest.GraphJSONObjectCallback() {

--- a/Bumerang/build.gradle
+++ b/Bumerang/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
         
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
fixes #57 

Now the title in the actionbar (title header thing) changes with the page you're on (set each page). 

- one thing, the Edit Profile doesn't have it's own title - I couldn't get it to work without crashing the app, since when you first start up the app you get to a version of the Edit Profile page without an actionbar. If we could turn on the actionbar (without the menu button) for the first Edit Profile page, that should fix it - but I couldn't find where that was set (does anyone know?) Anyway, since we're changing the Edit Profile page soon (I think) I left it like that. 