### PR TITLE
Icon displayed after deletion of request

### DIFF
--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/adapters/MyRequestAdapter.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/adapters/MyRequestAdapter.java
@@ -5,6 +5,9 @@ package com.seng480b.bumerang.adapters;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -15,6 +18,7 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import com.seng480b.bumerang.R;
+import com.seng480b.bumerang.fragments.MyRequestsFragment;
 import com.seng480b.bumerang.interfaces.AsyncTaskHandler;
 import com.seng480b.bumerang.models.Request;
 import com.seng480b.bumerang.utils.RequestUtility;
@@ -29,10 +33,12 @@ public class MyRequestAdapter extends ArrayAdapter<Request> implements AsyncTask
     private ArrayList<Request> requests;
     private RequestUtility.DeleteRequestTask deleteRequestTask;
     private int currentPosition;
+    private Context context;
 
     public MyRequestAdapter(Context context, ArrayList<Request> requests) {
         super(context,0,requests);
         this.requests = requests;
+        this.context = context;
     }
 
     @Override
@@ -132,6 +138,7 @@ public class MyRequestAdapter extends ArrayAdapter<Request> implements AsyncTask
             longToast(getContext(), R.string.delete_request_success_message);
             requests.remove(currentPosition);
             notifyDataSetChanged();
+            reloadList();
         }
     }
 
@@ -143,5 +150,10 @@ public class MyRequestAdapter extends ArrayAdapter<Request> implements AsyncTask
         return deleteRequestTask.getStatus() != RequestUtility.DeleteRequestTask.Status.FINISHED;
     }
 
-
+    public void reloadList() {
+        FragmentTransaction ft = ((FragmentActivity)context).getSupportFragmentManager().beginTransaction();
+        Fragment my_requests = new MyRequestsFragment();
+        ft.replace(R.id.mainFrame, my_requests);
+        ft.commit();
+    }
 }

--- a/Bumerang/app/src/main/java/com/seng480b/bumerang/fragments/MyRequestsFragment.java
+++ b/Bumerang/app/src/main/java/com/seng480b/bumerang/fragments/MyRequestsFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
@@ -16,9 +15,7 @@ import android.support.v4.app.ListFragment;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.ActionMode;
-import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -48,8 +45,6 @@ import com.seng480b.bumerang.utils.Utility;
 
 import java.util.ArrayList;
 
-import static android.R.attr.statusBarColor;
-import static com.seng480b.bumerang.utils.Utility.getCurrentRequestType;
 import static com.seng480b.bumerang.utils.Utility.longToast;
 
 public class MyRequestsFragment extends ListFragment implements OnItemClickListener, AsyncTaskHandler {
@@ -244,6 +239,7 @@ public class MyRequestsFragment extends ListFragment implements OnItemClickListe
                 MyRequestAdapter deleteAdapter = (MyRequestAdapter) listView.getAdapter();
                 deleteAdapter.remove(request);
                 deleteAdapter.notifyDataSetChanged();
+                reloadList();
             }
         }
 
@@ -259,6 +255,14 @@ public class MyRequestsFragment extends ListFragment implements OnItemClickListe
             requestUtility = new RequestUtility<>(this);
             this.request = request;
             deleteRequestTask = requestUtility.deleteRequest(getContext(), request.getRequestId());
+        }
+
+        public void reloadList() {
+            FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
+            Fragment my_requests = new MyRequestsFragment();
+            ft.addToBackStack("my_requests");
+            ft.replace(R.id.mainFrame, my_requests);
+            ft.commit();
         }
     }
 


### PR DESCRIPTION
Fixed issue #161 
Main issue was more complicated than we thought, After deletion of an accepted request the list item that takes its place also can be clicked to open up the previously deleted requests information.